### PR TITLE
Add CP-SAT based solver binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -378,7 +378,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -582,10 +582,10 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -662,6 +662,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "cp_sat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c974d3de62545fc4563bf6da4e3a4be9c862ac2074013ec74e58c99e672b72e"
+dependencies = [
+ "bytes",
+ "cc",
+ "libc",
+ "prost",
+ "prost-build",
+ "smallvec",
 ]
 
 [[package]]
@@ -767,7 +781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -778,7 +792,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -814,7 +828,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -824,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -844,7 +858,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -856,7 +870,7 @@ checksum = "ccfae181bab5ab6c5478b2ccb69e4c68a02f8c3ec72f6616bfec9dbc599d2ee0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -877,7 +891,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -946,6 +960,12 @@ name = "find-msvc-tools"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -1150,7 +1170,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1169,7 +1189,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1194,9 +1214,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -1209,6 +1244,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1389,6 +1433,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "clap",
+ "cp_sat",
  "ctrlc",
  "fs_extra",
  "getrandom 0.3.3",
@@ -1563,12 +1608,22 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1625,6 +1680,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1737,6 +1801,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -1846,6 +1916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "mysql"
 version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,13 +1951,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66f62cad7623a9cb6f8f64037f0c4f69c8db8e82914334a83c9788201c2c1bfa"
 dependencies = [
  "darling",
- "heck",
+ "heck 0.5.0",
  "num-bigint",
  "proc-macro-crate",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "termcolor",
  "thiserror",
 ]
@@ -2101,7 +2177,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2201,7 +2277,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2212,6 +2288,16 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2309,7 +2395,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2326,6 +2412,57 @@ name = "proconio"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c10091de86d0dc939b37a115d74597cbe83af470032a1729d50c98ccee043cb0"
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes",
+ "prost",
+]
 
 [[package]]
 name = "quick-error"
@@ -2571,6 +2708,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
@@ -2578,7 +2728,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
 
@@ -2781,7 +2931,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2964,6 +3114,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
@@ -2990,7 +3151,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3023,7 +3184,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.8",
  "windows-sys 0.60.2",
 ]
 
@@ -3053,7 +3214,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3165,7 +3326,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3213,7 +3374,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3283,7 +3444,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3369,6 +3530,12 @@ name = "unicode-script"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-vo"
@@ -3525,7 +3692,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -3560,7 +3727,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3599,6 +3766,18 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
 
 [[package]]
 name = "winapi"
@@ -3652,7 +3831,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3663,7 +3842,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3904,7 +4083,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3925,7 +4104,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3945,7 +4124,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3985,7 +4164,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rustsat-kissat = "0.7.3"
 rustsat-minisat = "0.7.3"
 rustsat-glucose = "0.7.3"
 ordered-float = "5.0.0"
+cp_sat = "0.3.3"
 
 [profile.release]
 debug = true

--- a/src/bin/cp_sat.rs
+++ b/src/bin/cp_sat.rs
@@ -1,0 +1,566 @@
+// EVOLVE-BLOCK-START
+#![allow(
+    clippy::needless_range_loop,
+    clippy::useless_vec,
+    clippy::partialeq_to_none,
+    clippy::if_same_then_else,
+    clippy::ptr_arg,
+    clippy::manual_memcpy,
+    clippy::cloned_ref_to_slice_refs,
+    non_snake_case,
+    unused_variables,
+    dead_code
+)]
+use cp_sat::builder::{BoolVar, CpModelBuilder};
+use cp_sat::proto::CpSolverStatus;
+use icfpc2025::{judge::*, *};
+use rand::prelude::*;
+use rand_chacha::ChaCha12Rng;
+use std::env;
+
+// ---------------------------- CP-SAT model -------------------------------
+
+struct Cnf {
+    model: CpModelBuilder,
+    buf: Vec<BoolVar>,
+}
+
+impl Cnf {
+    fn new() -> Self {
+        Self {
+            model: CpModelBuilder::default(),
+            buf: Vec::with_capacity(128),
+        }
+    }
+    #[inline]
+    fn var(&mut self) -> BoolVar {
+        self.model.new_bool_var()
+    }
+    #[inline]
+    fn clause<I: IntoIterator<Item = BoolVar>>(&mut self, lits: I) {
+        self.model.add_or(lits);
+    }
+    #[inline]
+    fn choose_one(&mut self, xs: &[BoolVar]) {
+        self.model.add_exactly_one(xs.iter().copied());
+    }
+    #[inline]
+    fn at_most_one(&mut self, xs: &[BoolVar]) {
+        self.model.add_at_most_one(xs.iter().copied());
+    }
+}
+
+// -------------------------- Combinatorial helpers ------------------------
+
+#[inline]
+fn compute_diff(plan: &[usize], labels: &[usize]) -> Vec<Vec<bool>> {
+    let m = labels.len();
+    let t = plan.len();
+    let mut diff = mat![false; m; m];
+    for i in (0..m).rev() {
+        for j in (0..m).rev() {
+            if labels[i] != labels[j] {
+                diff[i][j] = true;
+            } else if i < t && j < t && plan[i] == plan[j] && diff[i + 1][j + 1] {
+                diff[i][j] = true;
+            }
+        }
+    }
+    for i in 0..m {
+        diff[i][i] = false;
+        for j in 0..i {
+            let v = diff[i][j] || diff[j][i];
+            diff[i][j] = v;
+            diff[j][i] = v;
+        }
+    }
+    diff
+}
+
+// ------------------------------ Problem view -----------------------------
+
+struct PlanInfo {
+    n: usize,
+    plan: Vec<usize>,
+    labels: Vec<usize>,
+    t: usize,
+    m: usize,
+    diff: Vec<Vec<bool>>,
+}
+fn balanced_plan(n: usize, rng: &mut ChaCha12Rng) -> Vec<usize> {
+    let len = 18 * n;
+    let mut plan = Vec::with_capacity(len);
+    for d in 0..6 {
+        for _ in 0..(len / 6) {
+            plan.push(d);
+        }
+    }
+    plan.shuffle(rng);
+    plan
+}
+
+/*
+fn acquire_plan_and_labels(judge: &mut dyn icfpc2025::judge::Judge) -> PlanInfo {
+    let n = judge.num_rooms();
+    let mut rng = ChaCha12Rng::seed_from_u64(0xC0FF_EE42);
+    let plan = balanced_plan(n, &mut rng);
+    let labels = judge.explore(&vec![plan.clone()])[0].clone();
+    let m = labels.len();
+    let t = plan.len();
+    debug_assert_eq!(m, t + 1);
+    let diff = compute_diff(&plan, &labels);
+    PlanInfo { n, plan, labels, t, m, diff }
+}
+*/
+
+fn acquire_plan_and_labels(judge: &mut dyn icfpc2025::judge::Judge) -> PlanInfo {
+    let n = judge.num_rooms();
+
+    // Default plan strings for supported sizes
+    let default_plan_str = if n == 30 {
+        "413022551403315200442351124530532105441250342013450431221500235401332245541100524301142035531432234405215311350240015425104334025123304521120534103522445503114230032542135431452051002415012340523321554433021451132041025533014400351220440115324321342250451305502315412031045522433500142534115203442231104350310540221435132441500553020145133425523012412033443004231254411023052214500135410325345320121545042102113352405514315340154304422003355523411201445331322002514054225105033004323315550112134421441352532400511024124025405311304432221235"
+    } else if n == 24 {
+        "053421124355003145223044132102540153351203445023114200554324125133051042215014033152443520411325530244002234511032054154230134552103501221433402532514310044152332500144551240530123153410521354220330420524115043021334514011522400543355322502431104320154423513402104531230554420011342541350314220511225053310324405552341300214450322545125330150043123141012421453202513005434045013322443102352331551412002403415510035111204255404452032"
+    } else {
+        panic!("Unsupported number of rooms: {}", n);
+    };
+
+    // Allow override via environment variable PLAN_STR (string of digits 0-5)
+    let plan_str = env::var("PLAN_STR")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| default_plan_str.to_string());
+
+    let plan = plan_str
+        .chars()
+        .map(|c| c.to_digit(10).unwrap() as usize)
+        .collect::<Vec<_>>();
+
+    let labels = judge.explore(&vec![plan.clone()])[0].clone();
+    let m = labels.len();
+    let t = plan.len();
+    debug_assert_eq!(m, t + 1);
+    let diff = compute_diff(&plan, &labels);
+    PlanInfo {
+        n,
+        plan,
+        labels,
+        t,
+        m,
+        diff,
+    }
+}
+
+struct Buckets {
+    rooms_by_label: [Vec<usize>; 4],
+    times_by_label: [Vec<usize>; 4],
+}
+fn build_buckets(info: &PlanInfo) -> Buckets {
+    let mut rooms_by_label: [Vec<usize>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+    for u in 0..info.n {
+        rooms_by_label[u % 4].push(u);
+    }
+    let mut times_by_label: [Vec<usize>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+    for i in 0..info.m {
+        times_by_label[info.labels[i]].push(i);
+    }
+    Buckets {
+        rooms_by_label,
+        times_by_label,
+    }
+}
+
+struct Candidates {
+    // V_map[i][u] = Some(var) if room u allowed at time i (label match).
+    V_map: Vec<Vec<Option<BoolVar>>>,
+    // V_rows[i] = list of variables for time i.
+    V_rows: Vec<Vec<BoolVar>>,
+}
+fn build_candidates(cnf: &mut Cnf, info: &PlanInfo, buckets: &Buckets) -> Candidates {
+    let mut V_map: Vec<Vec<Option<BoolVar>>> = vec![vec![None; info.n]; info.m];
+    let mut V_rows: Vec<Vec<BoolVar>> = vec![Vec::new(); info.m];
+    for i in 0..info.m {
+        let k = info.labels[i];
+        let rooms = &buckets.rooms_by_label[k];
+        V_rows[i].reserve(rooms.len());
+        for &u in rooms {
+            let v = cnf.var();
+            V_map[i][u] = Some(v);
+            V_rows[i].push(v);
+        }
+        cnf.choose_one(&V_rows[i]);
+    }
+    Candidates { V_map, V_rows }
+}
+
+// -------------------------- Symmetry breaking ----------------------------
+
+fn first_use_sbp_rect_truncated(cnf: &mut Cnf, W_full: &[Vec<BoolVar>]) {
+    let t_all = W_full.len();
+    if t_all == 0 {
+        return;
+    }
+    let m = W_full[0].len();
+    if m == 0 {
+        return;
+    }
+    let t = std::cmp::min(t_all, m + 2);
+    let W = &W_full[0..t];
+
+    let mut z = vec![vec![BoolVar(0); m]; t];
+    let mut p = vec![vec![BoolVar(0); m]; t];
+    for i in 0..t {
+        for u in 0..m {
+            z[i][u] = cnf.var();
+            p[i][u] = cnf.var();
+        }
+    }
+    for i in 0..t {
+        for u in 0..m {
+            cnf.clause([!W[i][u], p[i][u]]);
+            cnf.clause([!z[i][u], W[i][u]]);
+            cnf.clause([!z[i][u], p[i][u]]);
+            if i == 0 {
+                cnf.clause([!p[0][u], z[0][u]]);
+                cnf.clause([!z[0][u], p[0][u]]);
+            } else {
+                cnf.clause([!p[i - 1][u], p[i][u]]);
+                cnf.clause([!p[i][u], p[i - 1][u], z[i][u]]);
+                cnf.clause([!z[i][u], !p[i - 1][u]]);
+            }
+        }
+    }
+    for i in 0..t {
+        for u in 1..m {
+            cnf.clause([!p[i][u], p[i][u - 1]]);
+        }
+    }
+}
+
+fn add_sbp(cnf: &mut Cnf, info: &PlanInfo, buckets: &Buckets, cand: &Candidates) {
+    // Per-label rectangular first-use SBP with truncation and anchor earliest to smallest room.
+    for k in 0..4 {
+        let times = &buckets.times_by_label[k];
+        if times.is_empty() {
+            continue;
+        }
+        let rooms = &buckets.rooms_by_label[k];
+        let mut W: Vec<Vec<BoolVar>> = Vec::with_capacity(times.len());
+        for &i in times {
+            let mut row = Vec::with_capacity(rooms.len());
+            for &u in rooms {
+                let var = cand.V_map[i][u].unwrap();
+                row.push(var);
+            }
+            W.push(row);
+        }
+        // Anchor earliest occurrence to smallest room of this label
+        cnf.clause([W[0][0]]);
+        first_use_sbp_rect_truncated(cnf, &W);
+    }
+
+    // Also pin the first seen time of each label to the canonical u=k if present.
+    let mut seen = [false; 4];
+    for i in 0..info.m {
+        let k = info.labels[i];
+        if !seen[k] {
+            seen[k] = true;
+            if let Some(v) = cand.V_map[i][k] {
+                cnf.clause([v]);
+            }
+        }
+    }
+}
+
+fn add_diff_pruning(cnf: &mut Cnf, info: &PlanInfo, buckets: &Buckets, cand: &Candidates) {
+    for i in 0..info.m {
+        for j in (i + 1)..info.m {
+            if info.labels[i] == info.labels[j] && info.diff[i][j] {
+                let k = info.labels[i];
+                for &u in &buckets.rooms_by_label[k] {
+                    let vi = cand.V_map[i][u].unwrap();
+                    let vj = cand.V_map[j][u].unwrap();
+                    cnf.clause([!vi, !vj]);
+                }
+            }
+        }
+    }
+}
+
+// Equalization: for pairs (i,j) with same (label,door,next-label) and not yet distinguishable on next,
+// enforce (V[i]=u ∧ V[j]=u ∧ V[i+1]=v) -> V[j+1]=v for all u,v in the respective label buckets.
+fn add_same_door_equalization(
+    cnf: &mut Cnf,
+    info: &PlanInfo,
+    buckets: &Buckets,
+    cand: &Candidates,
+) {
+    let mut idx_by_ke: Vec<Vec<Vec<usize>>> = vec![vec![Vec::new(); 6]; 4];
+    for i in 0..info.t {
+        idx_by_ke[info.labels[i]][info.plan[i]].push(i);
+    }
+    for k in 0..4 {
+        for e in 0..6 {
+            let idxs = &idx_by_ke[k][e];
+            if idxs.len() <= 1 {
+                continue;
+            }
+            for a in 0..idxs.len() {
+                for b in (a + 1)..idxs.len() {
+                    let i = idxs[a];
+                    let j = idxs[b];
+                    if info.labels[i + 1] != info.labels[j + 1] || info.diff[i + 1][j + 1] {
+                        continue;
+                    }
+                    let h = info.labels[i + 1];
+                    for &u in &buckets.rooms_by_label[k] {
+                        let vi = cand.V_map[i][u].unwrap();
+                        let vj = cand.V_map[j][u].unwrap();
+                        for &v in &buckets.rooms_by_label[h] {
+                            let qi = cand.V_map[i + 1][v].unwrap();
+                            let qj = cand.V_map[j + 1][v].unwrap();
+                            cnf.clause([!vi, !vj, !qi, qj]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -------------------------- Edge variable layer --------------------------
+
+struct EdgeVars {
+    // Tlab[u][e][k]
+    Tlab: Vec<Vec<[BoolVar; 4]>>,
+    // F[u][e][v]
+    F: Vec<Vec<Vec<BoolVar>>>,
+    // M[u][v][e][f] symmetric shared
+    M: Vec<Vec<[[BoolVar; 6]; 6]>>,
+}
+fn build_edge_vars(cnf: &mut Cnf, info: &PlanInfo) -> EdgeVars {
+    let n = info.n;
+    let mut Tlab = vec![vec![[BoolVar(0); 4]; 6]; n];
+    let mut F = mat![BoolVar(0); n; 6; n];
+
+    for u in 0..n {
+        for e in 0..6 {
+            let mut trow = [BoolVar(0); 4];
+            for k in 0..4 {
+                Tlab[u][e][k] = cnf.var();
+                trow[k] = Tlab[u][e][k];
+            }
+            cnf.choose_one(&trow);
+
+            let mut frow = Vec::with_capacity(n);
+            for v in 0..n {
+                F[u][e][v] = cnf.var();
+                frow.push(F[u][e][v]);
+                cnf.clause([!F[u][e][v], Tlab[u][e][v % 4]]);
+            }
+            cnf.choose_one(&frow);
+        }
+    }
+
+    for u in 0..n {
+        for e in 0..6 {
+            for k in 0..4 {
+                cnf.buf.clear();
+                cnf.buf.push(!Tlab[u][e][k]);
+                for v in (k..n).step_by(4) {
+                    cnf.buf.push(F[u][e][v]);
+                }
+                cnf.clause(cnf.buf.clone());
+            }
+        }
+    }
+
+    let mut M = vec![vec![[[BoolVar(0); 6]; 6]; n]; n];
+    for u in 0..n {
+        for v in u..n {
+            for e in 0..6 {
+                for f in 0..6 {
+                    let var = cnf.var();
+                    M[u][v][e][f] = var;
+                    M[v][u][f][e] = var;
+                }
+            }
+        }
+    }
+    // M -> F both endpoints
+    for u in 0..n {
+        for v in 0..n {
+            for e in 0..6 {
+                for f in 0..6 {
+                    let mv = M[u][v][e][f];
+                    cnf.clause([!mv, F[u][e][v]]);
+                    cnf.clause([!mv, F[v][f][u]]);
+                }
+            }
+        }
+    }
+    // Row-wise: F[u][e][v] -> OR_f M[u][v][e][f]; AMO on f
+    for u in 0..n {
+        for v in 0..n {
+            for e in 0..6 {
+                let mut row = [BoolVar(0); 6];
+                for f in 0..6 {
+                    row[f] = M[u][v][e][f];
+                }
+                cnf.buf.clear();
+                cnf.buf.push(!F[u][e][v]);
+                cnf.buf.extend_from_slice(&row);
+                cnf.clause(cnf.buf.clone());
+                cnf.at_most_one(&row);
+            }
+        }
+    }
+    // Column-wise: F[v][f][u] -> OR_e M[u][v][e][f]; AMO on e
+    for u in 0..n {
+        for v in 0..n {
+            for f in 0..6 {
+                let mut col = [BoolVar(0); 6];
+                for e in 0..6 {
+                    col[e] = M[u][v][e][f];
+                }
+                cnf.buf.clear();
+                cnf.buf.push(!F[v][f][u]);
+                cnf.buf.extend_from_slice(&col);
+                cnf.clause(cnf.buf.clone());
+                cnf.at_most_one(&col);
+            }
+        }
+    }
+
+    EdgeVars { Tlab, F, M }
+}
+
+fn add_plan_constraints(
+    cnf: &mut Cnf,
+    info: &PlanInfo,
+    buckets: &Buckets,
+    cand: &Candidates,
+    edges: &EdgeVars,
+) {
+    // V[i]=u -> Tlab[u, plan[i], labels[i+1]]
+    for i in 0..info.t {
+        let e = info.plan[i];
+        let h = info.labels[i + 1];
+        let k = info.labels[i];
+        for &u in &buckets.rooms_by_label[k] {
+            let vi = cand.V_map[i][u].unwrap();
+            cnf.clause([!vi, edges.Tlab[u][e][h]]);
+        }
+    }
+    // (V[i]=u ∧ V[i+1]=v) -> F[u, plan[i], v]
+    for i in 0..info.t {
+        let e = info.plan[i];
+        let k = info.labels[i];
+        let h = info.labels[i + 1];
+        for &u in &buckets.rooms_by_label[k] {
+            let vi = cand.V_map[i][u].unwrap();
+            for &v in &buckets.rooms_by_label[h] {
+                let vj = cand.V_map[i + 1][v].unwrap();
+                cnf.clause([!vi, !vj, edges.F[u][e][v]]);
+            }
+        }
+    }
+}
+
+// -------------------------- Extraction -----------------------------------
+
+fn extract_guess(
+    response: &cp_sat::proto::CpSolverResponse,
+    info: &PlanInfo,
+    buckets: &Buckets,
+    cand: &Candidates,
+    edges: &EdgeVars,
+) -> Guess {
+    let n = info.n;
+    let mut guess = Guess {
+        start: 0,
+        rooms: vec![0; n],
+        graph: vec![[(!0, !0); 6]; n],
+    };
+
+    // Start room: find true variable at time 0
+    {
+        let k0 = info.labels[0];
+        let rooms0 = &buckets.rooms_by_label[k0];
+        let mut s = rooms0[0];
+        for &u in rooms0 {
+            let v = cand.V_map[0][u].unwrap();
+            if v.solution_value(response) {
+                s = u;
+                break;
+            }
+        }
+        guess.start = s;
+    }
+
+    for u in 0..n {
+        guess.rooms[u] = u % 4;
+    }
+
+    for u in 0..n {
+        for e in 0..6 {
+            let mut v_sel = 0usize;
+            for v in 0..n {
+                if edges.F[u][e][v].solution_value(response) {
+                    v_sel = v;
+                    break;
+                }
+            }
+            let mut f_sel = 0usize;
+            for f in 0..6 {
+                if edges.M[u][v_sel][e][f].solution_value(response) {
+                    f_sel = f;
+                    break;
+                }
+            }
+            guess.graph[u][e] = (v_sel, f_sel);
+        }
+    }
+    guess
+}
+
+// ------------------------------ Main solve -------------------------------
+
+fn solve(judge: &mut dyn icfpc2025::judge::Judge) {
+    // 1) Acquire single explore trace with a balanced, shuffled plan
+    let info = acquire_plan_and_labels(judge);
+
+    // 2) Build buckets and candidates
+    let buckets = build_buckets(&info);
+    let mut cnf = Cnf::new();
+    let cand = build_candidates(&mut cnf, &info, &buckets);
+
+    // 3) Add pruning and symmetry breaking
+    add_diff_pruning(&mut cnf, &info, &buckets, &cand);
+    add_sbp(&mut cnf, &info, &buckets, &cand);
+    add_same_door_equalization(&mut cnf, &info, &buckets, &cand);
+
+    // 4) Edge layer and plan constraints
+    let edges = build_edge_vars(&mut cnf, &info);
+    add_plan_constraints(&mut cnf, &info, &buckets, &cand, &edges);
+
+    // 5) Solve
+    let response = cnf.model.solve();
+    assert_eq!(response.status(), CpSolverStatus::Optimal);
+
+    // 6) Extract and verify
+    let guess = extract_guess(&response, &info, &buckets, &cand, &edges);
+    assert!(check_explore(
+        &guess,
+        &[info.plan.clone()],
+        &[info.labels.clone()]
+    ));
+    judge.guess(&guess);
+}
+// EVOLVE-BLOCK-END
+
+fn main() {
+    let mut judge = icfpc2025::judge::get_judge_from_stdin();
+    solve(judge.as_mut());
+}


### PR DESCRIPTION
## Summary
- add new cp_sat binary using cp_sat crate instead of cadical
- use built-in at-most-one and exactly-one constraints via cp_sat
- wire solver extraction through CpSolverResponse

## Testing
- `cargo build` *(fails: cp_sat wrapper could not compile with installed OR-Tools)*
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f0f11dc8326a91dbf593d4af61b