### PR TITLE
feat: add recent guesses display to leaderboard page

### DIFF
--- a/src/www/handlers/leaderboard.rs
+++ b/src/www/handlers/leaderboard.rs
@@ -406,7 +406,7 @@ async fn fetch_snapshots(problem: &str) -> Result<Vec<Snapshot>> {
 
 /// 最近の提出（guess）を取得してHTMLとして返す関数
 async fn recent_guesses(problem: &str) -> Result<String> {
-    // 直近10件の正解・不正解のguessを取得
+    // 直近の提出（guess）を取得
     let rows = if problem != "global" {
         sql::select(
             "
@@ -457,7 +457,8 @@ async fn recent_guesses(problem: &str) -> Result<String> {
         let correct = row.at::<bool>(3)?;
         let map = row.at::<String>(4)?;
         // compact
-        let map = serde_json::to_string(&serde_json::from_str::<api::Map>(&map)?)?;
+        let map_value: serde_json::Value = serde_json::from_str(&map)?;
+        let map = serde_json::to_string(&map_value)?;
         let map_leading_part = &map[..100.min(map.len())];
         write!(
             w,


### PR DESCRIPTION
This pull request enhances the leaderboard page by adding a new section that displays recent guesses submitted for each problem. The changes improve the user experience by providing more visibility into recent activity and making navigation clearer.

**Leaderboard page enhancements:**

* Added a new `recent_guesses` async function in `leaderboard.rs` to fetch and render recent guesses for a problem, showing the last 20 guesses for specific problems and the last 100 for the global leaderboard. The output includes details such as ID, timestamp, problem name, truncated map, and correctness.
* Updated the leaderboard page to display a "Recent guesses submitted" section above the "Latest successful map" section, integrating the output from the new `recent_guesses` function.

**Navigation improvements:**

* Improved the navigation links so that the currently viewed problem is highlighted in bold, making it easier for users to see which leaderboard they are viewing.

**Codebase updates:**

* Added `mysql::prelude::*` import to support additional MySQL query functionality required by the new feature.