### PR TITLE
feat: add best scores retrieval and highlight for Unagi scores

### DIFF
--- a/src/www/handlers/leaderboard.rs
+++ b/src/www/handlers/leaderboard.rs
@@ -140,7 +140,7 @@ async fn render_problem_leaderboard(problem: &str, nocache: bool) -> Result<Stri
             best.map_or("-".to_string(), |s| s.to_string())
         );
         // Unagiのスコアが最良でない場合は赤くする
-        if let (Some(unagi_score), Some(best_score)) = (scores.get(p), best_scores.get(p))
+        if let (Some(unagi_score), Some(best_score)) = (score, best)
             && unagi_score > best_score
         {
             link = format!(r#"<span style="color:red;">{}</span>"#, link);


### PR DESCRIPTION
This pull request updates the leaderboard navigation to display both Unagi's score and the best score for each problem, and visually highlights problems where Unagi's score is not the best. The code also adds a query to fetch the best score for each problem from the database.

**Leaderboard navigation improvements:**

* Added a SQL query to fetch the minimum (best) score for each problem from the `scores` table, storing results in a new `best_scores` map.
* Updated the navigation links to show both Unagi's score and the best score for each problem, separated by a slash (e.g., `[problem](unagi_score/best_score)`).
* Added logic to highlight the score in red when Unagi's score is worse than the best score for that problem.

**Code organization:**

* Added a new import for `problems` to the top of `leaderboard.rs` to support the updated navigation logic.