### PR TITLE
History

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -216,7 +216,10 @@ struct SelectResponse {
 #[cfg(feature = "reqwest")]
 pub fn select(problem_name: &str) -> Result<String> {
     // Acquire process-wide lock and start renewal thread, unless in direct mode.
-    let is_direct = matches!(std::env::var("AEDIFICIUM_ENDPOINT").ok().as_deref(), Some("direct"));
+    let is_direct = matches!(
+        std::env::var("AEDIFICIUM_ENDPOINT").ok().as_deref(),
+        Some("direct")
+    );
     if !is_direct {
         start_lock_manager_blocking()?;
     }
@@ -376,7 +379,7 @@ pub fn guess(map: &Map) -> Result<bool> {
 }
 
 #[cfg(feature = "reqwest")]
-#[cached(result = true, time = 300)]
+#[cached(result = true, time = 300, result_fallback = true)]
 pub fn scores() -> Result<HashMap<String, i64>> {
     let client = &*client::BLOCKING_CLIENT;
     // This endpoint is not proxied.
@@ -405,10 +408,7 @@ pub fn scores() -> Result<HashMap<String, i64>> {
 pub fn ping_root() -> Result<()> {
     let client = &*client::BLOCKING_CLIENT;
     let url = format!("{}/", aedificium_base());
-    let res = client
-        .get(&url)
-        .send()
-        .context("Failed to GET /")?;
+    let res = client.get(&url).send().context("Failed to GET /")?;
     let status = res.status();
     log_unagi_header(&res);
     // Treat 2xx as well as 400/404 as normal for measurement purposes.


### PR DESCRIPTION
This pull request refactors the leaderboard history and chart rendering logic to improve performance and clarity, shifting from a snapshot-based approach to a per-team score history. It also introduces more robust error handling for score fetching, changes the leaderboard auto-refresh interval, and simplifies the chart data structure for better maintainability.

**Leaderboard history and chart rendering improvements:**

* Refactored from fetching and displaying leaderboard snapshots (`fetch_snapshots`) to a new per-team score history structure (`fetch_history`), resulting in a more efficient and accurate representation of score progression for each team. This affects both backend data fetching and frontend chart rendering logic. [[1]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342L169-R200) [[2]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342L231-R260) [[3]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342L245-R276) [[4]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342L476-R547)
* Updated the downsampling logic to operate per team, ensuring that each team's score history is limited to around 100 points for performance, and changed the data structure sent to the client to a `HashMap<String, Vec<(String, i64)>>` (team to list of timestamped scores).

**Frontend chart and UI adjustments:**

* Simplified chart data construction on the frontend: the chart now directly uses per-team time series data, and the point radius for all teams is unified for clarity.
* Removed the snapshot count display from the leaderboard UI to reflect the new history-based approach.

**Error handling and reliability:**

* Improved error handling when fetching scores: if the API fails, the code now falls back to querying the database for the latest scores, ensuring the leaderboard remains functional.

**Other improvements:**

* Changed leaderboard auto-refresh interval from 1 minute to 5 minutes to reduce unnecessary reloads and server load.
* Minor code cleanups and dependency additions, such as introducing `itertools` and removing unused structures. [[1]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342R13) [[2]](diffhunk://#diff-198b040cdcac383191ad29568f8979abc43eafda677b159d8c90b3a68de45342L461-L466)

These changes collectively make the leaderboard more robust, efficient, and maintainable, especially as data volume grows.